### PR TITLE
Remove 'cat' commands from build.yml.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,6 @@ jobs:
           zip -j "${OUT_BASE}/windows/amd64/synkctl_windows_amd64.zip" "${OUT_BASE}/windows/amd64/synkctl.exe"
           tar -czvf "${OUT_BASE}/linux/amd64/synkctl_linux_amd64.tar.gz" -C "${OUT_BASE}/linux/amd64" synkctl
           tar -czvf "${OUT_BASE}/linux/arm64/synkctl_linux_arm64.tar.gz" -C "${OUT_BASE}/linux/arm64" synkctl
-          tree ./bin
 
       - name: create release
         env:
@@ -71,9 +70,7 @@ jobs:
             -F commitish=${{ env.RELEASE_VERSION }} \
             -F tag_name=${{ env.RELEASE_VERSION }} \
             > tmp-release-notes.json
-          cat tmp-release-notes.json
           jq -r .body tmp-release-notes.json > tmp-release-notes.md
-          cat tmp-release-notes.md
           gh release create ${{ env.RELEASE_VERSION }} \
             -t "synkctl ${RELEASE_VERSION}" \
             -F tmp-release-notes.md \


### PR DESCRIPTION
The build.yml had 'cat' commands to view the MD file generated for the release during the build. They're no longer needed.